### PR TITLE
systemd-bootchart: Trivial typo fix in warning

### DIFF
--- a/src/bootchart/bootchart.c
+++ b/src/bootchart/bootchart.c
@@ -531,7 +531,7 @@ int main(int argc, char *argv[]) {
 
         /* don't complain when overrun once, happens most commonly on 1st sample */
         if (overrun > 1)
-                log_warning("systemd-boochart: sample time overrun %i times\n", overrun);
+                log_warning("systemd-bootchart: sample time overrun %i times\n", overrun);
 
         return 0;
 }


### PR DESCRIPTION
Signed-off-by: Gianpaolo Macario gmacario@gmail.com
